### PR TITLE
Enable Previews support

### DIFF
--- a/ScrollableSimulator/Notification+.swift
+++ b/ScrollableSimulator/Notification+.swift
@@ -5,7 +5,9 @@ extension Notification {
         guard let app = self.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else {
             return false
         }
-        return app.bundleIdentifier == SIMULATOR_BUNDLE_ID
+        let bundleId = app.bundleIdentifier ?? ""
+        return bundleId == SIMULATOR_BUNDLE_ID
+            || (bundleId.contains("Xcode") && bundleId.contains("Previews"))
     }
 
     func getSimulatorPID() -> pid_t? {

--- a/ScrollableSimulator/SimulatorApp.swift
+++ b/ScrollableSimulator/SimulatorApp.swift
@@ -2,10 +2,26 @@ import Cocoa
 
 let SIMULATOR_BUNDLE_ID = "com.apple.iphonesimulator"
 
+// Xcode Previews runs its own simulator process whose bundle identifier
+// contains both "Xcode" and "Previews". Include it so scrolling also works
+// when using SwiftUI previews.
+
 class SimulatorApp {
     static func getSimulatorPID() -> pid_t? {
-        NSWorkspace.shared.runningApplications
-            .first(where: { $0.bundleIdentifier == SIMULATOR_BUNDLE_ID })?
-            .processIdentifier
+        if let app = NSWorkspace.shared.runningApplications
+            .first(where: { $0.bundleIdentifier == SIMULATOR_BUNDLE_ID }) {
+            return app.processIdentifier
+        }
+        // When using SwiftUI previews the simulator is launched inside
+        // Xcode. Look for applications whose bundle identifier includes
+        // "Xcode" and "Previews" to support this case.
+        if let app = NSWorkspace.shared.runningApplications
+            .first(where: { app in
+                guard let id = app.bundleIdentifier else { return false }
+                return id.contains("Xcode") && id.contains("Previews")
+            }) {
+            return app.processIdentifier
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## Summary
- detect Xcode Previews simulator by its bundle identifier
- handle Preview notifications as if they were from Simulator

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686c69d73f688325a0174f54535f9f6c